### PR TITLE
Use clang builtins

### DIFF
--- a/include/source_location/source_location.hpp
+++ b/include/source_location/source_location.hpp
@@ -56,6 +56,8 @@
 
     #if defined(_MSC_VER)
       #define current() current( __LINE__ , 0, __FILE__ , __func__ )
+    #elif defined(__clang__)
+      #define current(args...) current( __builtin_LINE() , __builtin_COLUMN(), __builtin_FILE() , __builtin_FUNCTION() )
     #else
       #define current(args...) current( __LINE__ , 0, __FILE__ , __PRETTY_FUNCTION__ )
     #endif


### PR DESCRIPTION
When the official source_location is unavailable, 
the macros like "__LINE__" don't work as default parameters
in functions defined in the top level. (At least, they don't work
in Mac+Clang).

However, using Clang builtins like "__builtin_LINE()", it works as expected.
Documentation: https://clang.llvm.org/docs/LanguageExtensions.html#source-location-builtins